### PR TITLE
feat: Add `name_scheme.uppercase` flag + bump CI + bump submodules + pin provider to `0.x`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,25 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: "v0.1.23" # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+    rev: "v0.1.25" # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
     hooks:
       - id: terraform-validate # It should be the first step as it runs terraform init required by tflint
       - id: terraform-fmt
       - id: tflint
-        # args:
-        #   - "--config=__GIT_ROOT__/.tflint.hcl"
 
   - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.18.0" # Get the latest from: https://github.com/terraform-docs/terraform-docs/releases
+    rev: "v0.19.0" # Get the latest from: https://github.com/terraform-docs/terraform-docs/releases
     hooks:
       - id: terraform-docs-go
         args: ["."]
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: "3.2.216" # Get the latest from: https://github.com/bridgecrewio/checkov/releases
+    rev: "3.2.350" # Get the latest from: https://github.com/bridgecrewio/checkov/releases
     hooks:
       - id: checkov
         args: [--skip-check, "CKV_TF_1"] # Terraform module sources do not use a git url with a commit hash revision
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.6.0" # Get the latest from: https://github.com/pre-commit/pre-commit-hooks/releases
+    rev: "v5.0.0" # Get the latest from: https://github.com/pre-commit/pre-commit-hooks/releases
     hooks:
       - id: check-merge-conflict
         args: ["--assume-in-merge"]

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ List od code and variable (API) changes:
 | <a name="input_encryption"></a> [encryption](#input\_encryption) | Specifies the encryption settings for the stage | `string` | `null` | no |
 | <a name="input_file_format"></a> [file\_format](#input\_file\_format) | Specifies the file format for the stage | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | n/a | yes |
-| <a name="input_name_scheme"></a> [name\_scheme](#input\_name\_scheme) | Naming scheme configuration for the resource. This configuration is used to generate names using context provider:<br>    - `properties` - list of properties to use when creating the name - is superseded by `var.context_templates`<br>    - `delimiter` - delimited used to create the name from `properties` - is superseded by `var.context_templates`<br>    - `context_template_name` - name of the context template used to create the name<br>    - `replace_chars_regex` - regex to use for replacing characters in property-values created by the provider - any characters that match the regex will be removed from the name<br>    - `extra_values` - map of extra label-value pairs, used to create a name | <pre>object({<br>    properties            = optional(list(string), ["name"])<br>    delimiter             = optional(string, "_")<br>    context_template_name = optional(string, "snowflake-stage")<br>    replace_chars_regex   = optional(string, "[^a-zA-Z0-9_]")<br>    extra_values          = optional(map(string))<br>  })</pre> | `{}` | no |
-| <a name="input_roles"></a> [roles](#input\_roles) | Database roles created in the stage scope | <pre>map(object({<br>    name_scheme = optional(object({<br>      properties            = optional(list(string))<br>      delimiter             = optional(string)<br>      context_template_name = optional(string)<br>      replace_chars_regex   = optional(string)<br>      extra_labels          = optional(map(string))<br>    }))<br>    comment                   = optional(string)<br>    with_grant_option         = optional(bool)<br>    granted_to_roles          = optional(list(string))<br>    granted_to_database_roles = optional(list(string))<br>    granted_database_roles    = optional(list(string))<br>    stage_grants              = optional(list(string))<br>    all_privileges            = optional(bool)<br>  }))</pre> | `{}` | no |
+| <a name="input_name_scheme"></a> [name\_scheme](#input\_name\_scheme) | Naming scheme configuration for the resource. This configuration is used to generate names using context provider:<br/>    - `properties` - list of properties to use when creating the name - is superseded by `var.context_templates`<br/>    - `delimiter` - delimited used to create the name from `properties` - is superseded by `var.context_templates`<br/>    - `context_template_name` - name of the context template used to create the name<br/>    - `replace_chars_regex` - regex to use for replacing characters in property-values created by the provider - any characters that match the regex will be removed from the name<br/>    - `extra_values` - map of extra label-value pairs, used to create a name<br/>    - `uppercase` - convert name to uppercase | <pre>object({<br/>    properties            = optional(list(string), ["name"])<br/>    delimiter             = optional(string, "_")<br/>    context_template_name = optional(string, "snowflake-stage")<br/>    replace_chars_regex   = optional(string, "[^a-zA-Z0-9_]")<br/>    extra_values          = optional(map(string))<br/>    uppercase             = optional(bool, true)<br/>  })</pre> | `{}` | no |
+| <a name="input_roles"></a> [roles](#input\_roles) | Database roles created in the stage scope | <pre>map(object({<br/>    name_scheme = optional(object({<br/>      properties            = optional(list(string))<br/>      delimiter             = optional(string)<br/>      context_template_name = optional(string)<br/>      replace_chars_regex   = optional(string)<br/>      extra_labels          = optional(map(string))<br/>      uppercase             = optional(bool)<br/>    }))<br/>    comment                   = optional(string)<br/>    with_grant_option         = optional(bool)<br/>    granted_to_roles          = optional(list(string))<br/>    granted_to_database_roles = optional(list(string))<br/>    granted_database_roles    = optional(list(string))<br/>    stage_grants              = optional(list(string))<br/>    all_privileges            = optional(bool)<br/>  }))</pre> | `{}` | no |
 | <a name="input_schema"></a> [schema](#input\_schema) | The schema in which to create the stage | `string` | n/a | yes |
 | <a name="input_snowflake_iam_user"></a> [snowflake\_iam\_user](#input\_snowflake\_iam\_user) | Specifies the Snowflake IAM user | `string` | `null` | no |
 | <a name="input_stage_ownership_grant"></a> [stage\_ownership\_grant](#input\_stage\_ownership\_grant) | To which account role the stage ownership should be granted | `string` | `null` | no |
@@ -136,8 +136,8 @@ List od code and variable (API) changes:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_roles_deep_merge"></a> [roles\_deep\_merge](#module\_roles\_deep\_merge) | Invicton-Labs/deepmerge/null | 0.1.5 |
-| <a name="module_snowflake_custom_role"></a> [snowflake\_custom\_role](#module\_snowflake\_custom\_role) | getindata/database-role/snowflake | 2.0.1 |
-| <a name="module_snowflake_default_role"></a> [snowflake\_default\_role](#module\_snowflake\_default\_role) | getindata/database-role/snowflake | 2.0.1 |
+| <a name="module_snowflake_custom_role"></a> [snowflake\_custom\_role](#module\_snowflake\_custom\_role) | getindata/database-role/snowflake | 2.1.0 |
+| <a name="module_snowflake_default_role"></a> [snowflake\_default\_role](#module\_snowflake\_default\_role) | getindata/database-role/snowflake | 2.1.0 |
 
 ## Outputs
 
@@ -152,7 +152,7 @@ List od code and variable (API) changes:
 | Name | Version |
 |------|---------|
 | <a name="provider_context"></a> [context](#provider\_context) | >=0.4.0 |
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.95 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.95 |
 
 ## Requirements
 
@@ -160,7 +160,7 @@ List od code and variable (API) changes:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_context"></a> [context](#requirement\_context) | >=0.4.0 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.95 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.95 |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -85,6 +85,7 @@ module "internal_stage_2" {
     extra_values = {
       project = "project"
     }
+    uppercase = false
   }
 
   schema   = snowflake_schema.this.name

--- a/locals.tf
+++ b/locals.tf
@@ -9,6 +9,7 @@ locals {
       schema = var.schema
       suffix = "stg"
     }
+    uppercase = var.name_scheme.uppercase
   }
 
   is_internal = var.url == null

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ data "context_label" "this" {
 }
 
 resource "snowflake_stage" "this" {
-  name     = data.context_label.this.rendered
+  name     = var.name_scheme.uppercase ? upper(data.context_label.this.rendered) : data.context_label.this.rendered
   database = var.database
   schema   = var.schema
 
@@ -41,13 +41,15 @@ resource "snowflake_grant_ownership" "stage_ownership" {
     object_type = "STAGE"
     object_name = snowflake_stage.this.fully_qualified_name
   }
+
+  depends_on = [snowflake_stage.this]
 }
 
 module "snowflake_default_role" {
   for_each = local.default_roles
 
   source  = "getindata/database-role/snowflake"
-  version = "2.0.1"
+  version = "2.1.0"
 
   database_name     = snowflake_stage.this.database
   context_templates = var.context_templates
@@ -76,13 +78,15 @@ module "snowflake_default_role" {
       }
     ]
   }
+
+  depends_on = [snowflake_stage.this]
 }
 
 module "snowflake_custom_role" {
   for_each = local.custom_roles
 
   source  = "getindata/database-role/snowflake"
-  version = "2.0.1"
+  version = "2.1.0"
 
   database_name     = snowflake_stage.this.database
   context_templates = var.context_templates
@@ -111,4 +115,6 @@ module "snowflake_custom_role" {
       }
     ]
   }
+
+  depends_on = [snowflake_stage.this]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,7 @@ variable "roles" {
       context_template_name = optional(string)
       replace_chars_regex   = optional(string)
       extra_labels          = optional(map(string))
+      uppercase             = optional(bool)
     }))
     comment                   = optional(string)
     with_grant_option         = optional(bool)
@@ -114,6 +115,7 @@ variable "name_scheme" {
     - `context_template_name` - name of the context template used to create the name
     - `replace_chars_regex` - regex to use for replacing characters in property-values created by the provider - any characters that match the regex will be removed from the name
     - `extra_values` - map of extra label-value pairs, used to create a name
+    - `uppercase` - convert name to uppercase
   EOT
   type = object({
     properties            = optional(list(string), ["name"])
@@ -121,6 +123,7 @@ variable "name_scheme" {
     context_template_name = optional(string, "snowflake-stage")
     replace_chars_regex   = optional(string, "[^a-zA-Z0-9_]")
     extra_values          = optional(map(string))
+    uppercase             = optional(bool, true)
   })
   default = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = ">= 0.95"
+      version = "~> 0.95"
     }
     context = {
       source  = "cloudposse/context"


### PR DESCRIPTION
* add `name_scheme.upper flag`, to create resources in uppercase
* CI workflow updates
* Bump submodule versions
* explicitly define dependencies
* pin provider to `0.x` version, since `resource "snowflake_stage"` is being reworked in `1.x` and has to be explicitly enabled as a preview feature