### PR TITLE
chore: Remove upper bound from provider version, bump snowflake-database-role version, documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ Please keep in mind to mirror this change in your own repos also.
 
 [Snowflake documentation](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/SNOWFLAKEDB_MIGRATION.md)
 
+## Preview Feature Requirements (Provider version 1.x+)
+
+Starting with Snowflake provider version `1.x`, the `snowflake_stage` resource is considered a preview feature and must be explicitly enabled in the provider configuration.
+
+**Required Provider Configuration:**
+
+```terraform
+provider "snowflake" {
+  preview_features_enabled = ["snowflake_stage_resource"]
+}
+```
+
+Without this configuration, you will encounter the following error:
+
+```shell
+Error: snowflake_stage_resource is currently a preview feature, and must be enabled by adding snowflake_stage_resource to preview_features_enabled in Terraform configuration.
+```
+
+For more information about preview features, refer to the [Snowflake provider documentation](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/stage#preview-features) and [Snowflake stage resource documentation](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/stage).
+
 <!-- BEGIN_TF_DOCS -->
 
 
@@ -144,8 +164,8 @@ Please keep in mind to mirror this change in your own repos also.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_roles_deep_merge"></a> [roles\_deep\_merge](#module\_roles\_deep\_merge) | Invicton-Labs/deepmerge/null | 0.1.5 |
-| <a name="module_snowflake_custom_role"></a> [snowflake\_custom\_role](#module\_snowflake\_custom\_role) | getindata/database-role/snowflake | 2.1.0 |
-| <a name="module_snowflake_default_role"></a> [snowflake\_default\_role](#module\_snowflake\_default\_role) | getindata/database-role/snowflake | 2.1.0 |
+| <a name="module_snowflake_custom_role"></a> [snowflake\_custom\_role](#module\_snowflake\_custom\_role) | getindata/database-role/snowflake | 3.0.0 |
+| <a name="module_snowflake_default_role"></a> [snowflake\_default\_role](#module\_snowflake\_default\_role) | getindata/database-role/snowflake | 3.0.0 |
 
 ## Outputs
 
@@ -160,7 +180,7 @@ Please keep in mind to mirror this change in your own repos also.
 | Name | Version |
 |------|---------|
 | <a name="provider_context"></a> [context](#provider\_context) | >=0.4.0 |
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.95 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.95 |
 
 ## Requirements
 
@@ -168,7 +188,7 @@ Please keep in mind to mirror this change in your own repos also.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_context"></a> [context](#requirement\_context) | >=0.4.0 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.95 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.95 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -105,31 +105,29 @@ List od code and variable (API) changes:
 
 ## Breaking changes in v4.x of the module
 
-Due to rename of Snowflake terraform provider source, all `versions.tf` files were updated accordingly.
+- Due to rename of Snowflake terraform provider source, all `versions.tf` files were updated accordingly.
 
-Please keep in mind to mirror this change in your own repos also.
+  Please keep in mind to mirror this change in your own repos also.
 
-[Snowflake documentation](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/SNOWFLAKEDB_MIGRATION.md)
+  For more information about provider rename, refer to [Snowflake documentation](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/SNOWFLAKEDB_MIGRATION.md).
 
-## Preview Feature Requirements (Provider version 1.x+)
+- Maximal version of supported provider was also unblocked in version `v4.1.x` , so keep in mind that, starting with Snowflake provider version `1.x`, the `snowflake_stage` resource is considered a preview feature and must be explicitly enabled in the provider configuration.
 
-Starting with Snowflake provider version `1.x`, the `snowflake_stage` resource is considered a preview feature and must be explicitly enabled in the provider configuration.
+  **Required Provider Configuration:**
 
-**Required Provider Configuration:**
+  ```terraform
+  provider "snowflake" {
+    preview_features_enabled = ["snowflake_stage_resource"]
+  }
+  ```
 
-```terraform
-provider "snowflake" {
-  preview_features_enabled = ["snowflake_stage_resource"]
-}
-```
+  Without this configuration, you will encounter the following error:
 
-Without this configuration, you will encounter the following error:
+  ```shell
+  Error: snowflake_stage_resource is currently a preview feature, and must be enabled by adding snowflake_stage_resource to preview_features_enabled in Terraform configuration.
+  ```
 
-```shell
-Error: snowflake_stage_resource is currently a preview feature, and must be enabled by adding snowflake_stage_resource to preview_features_enabled in Terraform configuration.
-```
-
-For more information about preview features, refer to the [Snowflake provider documentation](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/stage#preview-features) and [Snowflake stage resource documentation](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/stage).
+  For more information about preview features, refer to the [Snowflake provider documentation](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/stage#preview-features) and [Snowflake stage resource documentation](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/stage).
 
 <!-- BEGIN_TF_DOCS -->
 

--- a/examples/complete/providers.tf
+++ b/examples/complete/providers.tf
@@ -1,4 +1,6 @@
-provider "snowflake" {}
+provider "snowflake" {
+  preview_features_enabled = ["snowflake_stage_resource"]
+}
 
 provider "context" {
   properties = {

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,1 +1,3 @@
-provider "snowflake" {}
+provider "snowflake" {
+  preview_features_enabled = ["snowflake_stage_resource"]
+}

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ module "snowflake_default_role" {
   for_each = local.default_roles
 
   source  = "getindata/database-role/snowflake"
-  version = "2.1.0"
+  version = "3.0.0"
 
   database_name     = snowflake_stage.this.database
   context_templates = var.context_templates
@@ -82,7 +82,7 @@ module "snowflake_custom_role" {
   for_each = local.custom_roles
 
   source  = "getindata/database-role/snowflake"
-  version = "2.1.0"
+  version = "3.0.0"
 
   database_name     = snowflake_stage.this.database
   context_templates = var.context_templates

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "snowflakedb/snowflake"
-      version = "~> 0.95"
+      version = ">= 0.95"
     }
     context = {
       source  = "cloudposse/context"


### PR DESCRIPTION
* Upgrades Snowflake database role module to version 3.0.0 and adjusts provider version constraints to allow compatibility with newer versions. Improves table formatting in the documentation for better readability and updates provider configuration in Terraform examples.
* Add preview feature configuration for Snowflake stage resource
* Introduces explicit configuration to enable the `snowflake_stage` resource as a preview feature starting with provider version 1.x. Updates examples to include the required `preview_features_enabled` setting.
